### PR TITLE
Relecture page 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,42 +13,40 @@
 	<div class="span4">
 		<img src="img/harm-scar.png" alt="">
 		<h2 id="force">force</h2>
-<p><strong><em>Quand vous employez la force</em></strong>, jet+<code>Force</code> et choisissez parmi les options.</p>
-<p>Sur 12+, trois. Sur 10-11, deux. Sur 7-9, une.</p>
+<p><strong><em>Quand vous employez la force</em></strong>, additionnez un jet à votre<code>Force</code> et choisissez parmi les options.</p>
+<p>Avec 12 ou plus, trois options&nbsp;; 10-11, deux&nbsp;; 7-9, une.</p>
 <ul>
-<li>Vous infligez un grand Dommage.</li>
-<li>Vous recevez un léger Dommage en retour.</li>
-<li>Vous les repoussez, capturez quelque chose, ou créez une opportunité.</li>
+<li>Vous infligez un dommage important.</li>
+<li>Vous subissez peu de dommage en retour.</li>
+<li>Vous les repoussez, capturez quelque chose, ou profitez de la situation.</li>
 </ul>
 <h2 id="finesse">finesse</h2>
-<p><strong><em>Quand vous usez de finesse</em></strong>, jet+<code>Finesse</code> et choisissez parmi les options.</p>
-<p>Sur 12+, trois. Sur 10-11, deux. Sur 7-9, une.</p>
+<p><strong><em>Quand vous usez de finesse</em></strong>, additionnez un jet à votre <code>Finesse</code> et choisissez parmi les options.</p>
+<p>Avec 12 ou plus, trois options&nbsp;; 10-11, deux&nbsp;; 7-9, une.</p>
 <ul>
 <li>Vous le faites rapidement.</li>
-<li>Vous évitez les ennuis, d'être compromis, le prix à payer.</li>
-<li>Vous le faites de manière impressionnante, avec classe.</li>
+<li>Vous échappez aux ennuis, à la compromission, au prix à payer.</li>
+<li>Vous réussissez remarquablement, avec classe, ou avec un meilleur résultat.</li>
 </ul>
 <h2 id="lucidite">LuciditÉ</h2>
-<p><strong><em>Quand vous essayez d'être perspicace</em></strong>, jet+<code>Lucidité</code>.</p>
-<p>Sur 12+, gardez-en trois. Sur 10-11, gardez-en deux. Sur 7-9, gardez-en une.</p>
-<p>Conservez vos options en réserve en les troquant "une pour une" contre une
-question à poser au MdJ à tout moment de la scène.</p>
+<p><strong><em>Quand vous essayez d'être perspicace</em></strong>, additionnez un jet à votre <code>Lucidité</code>.</p>
+<p>Avec 12 ou plus, gardez trois options&nbsp;; 10-11, deux&nbsp;; 7-9, une. Échangez vos options contre autant de questions à poser au MdJ à tout moment de la scène.</p>
 <ul>
-<li>Que se passe-t-il vraiment ici ?</li>
-<li>Qu'est-ce que je dois regarder / chercher ?</li>
-<li>Quel est le meilleur moyen pour <strong><em>_</em></strong>______ ?</li>
-<li>Que ressentent-ils vraiment ?</li>
-<li>Que veulent-ils ?</li>
-<li>Comment faire pour qu'ils <strong><em>_</em></strong>____ ?</li>
+<li>Que se passe-t-il vraiment ici&nbsp;?</li>
+<li>À quoi devrais-je être attentif&nbsp;?</li>
+<li>Quel est le meilleur moyen pour ______&nbsp;?</li>
+<li>Que ressentent-ils vraiment&nbsp;?</li>
+<li>Que veulent-ils&nbsp;?</li>
+<li>Comment faire pour qu'ils ____&nbsp;?</li>
 </ul>
 <p><em>Sur un échec, vous n'avez pas d'option en réserve, mais vous pouvez poser une
 question immédiatement.</em></p>
 <h2 id="aider-interferer">Aider / InterfÉrer</h2>
-<p>Pour chaque mouvement ci-dessus (<code>Force</code>, <code>Finesse</code>, <code>Lucidité</code>), vous pouvez
-également dépenser une de vos options en tant qu'aide ou gêne :</p>
+<p>Pour chacune des actions précédentes (<code>Force</code>, <code>Finesse</code>, <code>Lucidité</code>), vous pouvez
+également dépenser une de vos options en tant qu'aide ou gêne&nbsp;:</p>
 <ul>
-<li>Vous aidez quelqu'un, ils reçoivent un bonus de +1 à leur jet.</li>
-<li>Vous gênez quelqu'un, ils reçoivent un malus de -2.</li>
+<li>Ceux que vous aidez reçoivent un bonus de +1 à leur jet.</li>
+<li>Ceux que vous gênez reçoivent un malus de -2.</li>
 </ul>
 	</div>
 	<div class="span4 text-center"><h2 id="the-third-age">The Third Age</h2>
@@ -57,33 +55,33 @@ question immédiatement.</em></p>
 	<div class="span4">
 		<img src="img/trauma-horror.png" alt="">
 		<h2 id="cran">Cran</h2>
-<p><strong><em>Quand vous résistez</em></strong>, à une blessure, une contrainte ou une horreur
-supernaturelle, choisissez parmi les options <strong>celle que vous ne voulez pas</strong>
-et faites un jet+<code>Cran</code>.</p>
-<p>Sur un 10+, aucune n'arrive. Sur un 7-9, le MdJ choisit une option hormis celle
+<p><strong><em>Quand vous essayez de résister</em></strong>, à une blessure, une contrainte ou une horreur
+supernaturelle, choisissez parmi les actions <strong>celle que vous espérez ne pas subir</strong>
+et additionnez un jet à votre <code>Cran</code>.</p>
+<p>Avec 10 ou plus, vous êtes totalement épargné. Entre 7 et 9, le MdJ choisit une action hormis celle
 que vous avez sélectionné. <em>Sur un échec, c'est celle que vous ne vouliez pas
-qui arrive !</em></p>
+qui arrive&nbsp;!</em></p>
 <ul>
 <li>Scotché, laissé là sans défense.</li>
 <li>Panique, fuite, retraite.</li>
-<li>Effondrement, laissez-aller, abandon.</li>
+<li>Effondrement, laisser-aller, abandon.</li>
 <li>Rage, perte de contrôle, provoque des dommages involontaires.</li>
-<li>Souffre un Trauma ou un Dommage supplémentaire.</li>
+<li>Souffre d'un trauma ou d'un dommage supplémentaire.</li>
 </ul>
 <h2 id="periode-creuse">PÉriode creuse</h2>
 <p>Quand vous êtes en période creuse, sans boulot, choisissez une option :</p>
 <ul>
-<li><strong>Aller au pub</strong> : Soigne le Trauma (si plus élevé que 6, descendez à 6, si
-  6 ou inférieur, passez à zéro).</li>
-<li><strong>Visitez le guérisseur</strong> : Soigne les Dommages (si plus élevé que 9,
-  descendez à 9. Si à 9, descendez à 6. Si 6 ou inférieur, tout est guéri).</li>
-<li><strong>Faites un petit job</strong> - au choix : videur, courrier, artisan, crematorium,
-  crime, distillerie, docks, forge, chasse-leviathan, abattoir, étable,
-  commerce. Récupérez 2-<code>Pécules</code> ou 1-<code>Faveur</code>.</li>
+<li><strong>Aller au pub</strong>&nbsp;: soigne le trauma (s'il est supérieur à 6, descendez à 6,
+s'il est inférieur ou égal à 6, passez à zéro).</li>
+<li><strong>Visiter le guérisseur</strong>&nbsp;: soigne les dommages (s'ils sont supérieurs à 9,
+  descendez à 9&nbsp;; égaux à 9, descendez à 6&nbsp;; inférieurd ou égaux à 6, tout est guéri).</li>
+<li><strong>Faire un petit boulot</strong> - au choix&nbsp;: videur, courrier, artisan, brigand, docker,
+chasse-leviathan, employé dans un crématorium, une distillerie, une forge, un abattoir, une étable,
+un commerce. Récupérez 2-<code>Pécules</code> ou 1-<code>Faveur</code>.</li>
 </ul>
-<p>Vous pouvez choisir de dépenser des <code>Jetons</code> (un pour un) pour chacune des
-options. Vous pouvez choisir deux fois la même option.</p>
-<p><strong><code>Note</code>: Quand on vous demande de faire un jet, prendez deux dés à 6 faces et 
+<p>Vous pouvez choisir de dépenser un <code>Jeton</code> par option supplémentaire.
+ Vous pouvez choisir deux fois la même option.</p>
+<p><strong><code>Note</code>&nbsp;: quand on vous demande de faire un jet, prenez deux dés à 6 faces et 
 additionnez-les.</strong></p>
 	</div>
 </div>

--- a/index.html
+++ b/index.html
@@ -13,37 +13,38 @@
 	<div class="span4">
 		<img src="img/harm-scar.png" alt="">
 		<h2 id="force">force</h2>
-<p><strong><em>Quand vous employez la force</em></strong>, additionnez un jet à votre<code>Force</code> et choisissez parmi les options.</p>
-<p>Avec 12 ou plus, trois options&nbsp;; 10-11, deux&nbsp;; 7-9, une.</p>
+<p><strong><em>Quand vous employez la force</em></strong>, jet+<code>Force</code> et choisissez parmi les options.</p>
+<p>Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.</p>
 <ul>
 <li>Vous infligez un dommage important.</li>
 <li>Vous subissez peu de dommage en retour.</li>
 <li>Vous les repoussez, capturez quelque chose, ou profitez de la situation.</li>
 </ul>
 <h2 id="finesse">finesse</h2>
-<p><strong><em>Quand vous usez de finesse</em></strong>, additionnez un jet à votre <code>Finesse</code> et choisissez parmi les options.</p>
-<p>Avec 12 ou plus, trois options&nbsp;; 10-11, deux&nbsp;; 7-9, une.</p>
+<p><strong><em>Quand vous usez de finesse</em></strong>, jet+<code>Finesse</code> et choisissez parmi les options. </p>
+<p>Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.</p>
 <ul>
 <li>Vous le faites rapidement.</li>
 <li>Vous échappez aux ennuis, à la compromission, au prix à payer.</li>
 <li>Vous réussissez remarquablement, avec classe, ou avec un meilleur résultat.</li>
 </ul>
 <h2 id="lucidite">LuciditÉ</h2>
-<p><strong><em>Quand vous essayez d'être perspicace</em></strong>, additionnez un jet à votre <code>Lucidité</code>.</p>
-<p>Avec 12 ou plus, gardez trois options&nbsp;; 10-11, deux&nbsp;; 7-9, une. Échangez vos options contre autant de questions à poser au MdJ à tout moment de la scène.</p>
+<p><strong><em>Quand vous essayez d'être perspicace</em></strong>, jet+<code>Lucidité</code>.</p>
+<p>Avec 12 ou plus, gardez-en trois ; 10-11, deux ; 7-9, une. Échangez vos options
+contre autant de questions à poser au MdJ à tout moment de la scène.</p>
 <ul>
-<li>Que se passe-t-il vraiment ici&nbsp;?</li>
-<li>À quoi devrais-je être attentif&nbsp;?</li>
-<li>Quel est le meilleur moyen pour ______&nbsp;?</li>
-<li>Que ressentent-ils vraiment&nbsp;?</li>
-<li>Que veulent-ils&nbsp;?</li>
-<li>Comment faire pour qu'ils ____&nbsp;?</li>
+<li>Que se passe-t-il vraiment ici ?</li>
+<li>À quoi devrais-je être attentif ?</li>
+<li>Quel est le meilleur moyen pour <strong><em>_</em></strong>______ ?</li>
+<li>Que ressentent-ils vraiment ?</li>
+<li>Que veulent-ils ?</li>
+<li>Comment faire pour qu'ils <strong><em>_</em></strong>____ ?</li>
 </ul>
 <p><em>Sur un échec, vous n'avez pas d'option en réserve, mais vous pouvez poser une
 question immédiatement.</em></p>
 <h2 id="aider-interferer">Aider / InterfÉrer</h2>
-<p>Pour chacune des actions précédentes (<code>Force</code>, <code>Finesse</code>, <code>Lucidité</code>), vous pouvez
-également dépenser une de vos options en tant qu'aide ou gêne&nbsp;:</p>
+<p>Pour chacun des mouvements précédents (<code>Force</code>, <code>Finesse</code>, <code>Lucidité</code>), vous
+pouvez également dépenser une de vos options en tant qu'aide ou gêne :</p>
 <ul>
 <li>Ceux que vous aidez reçoivent un bonus de +1 à leur jet.</li>
 <li>Ceux que vous gênez reçoivent un malus de -2.</li>
@@ -143,12 +144,13 @@ question immédiatement.</em></p>
 	<div class="span4">
 		<img src="img/trauma-horror.png" alt="">
 		<h2 id="cran">Cran</h2>
-<p><strong><em>Quand vous essayez de résister</em></strong>, à une blessure, une contrainte ou une horreur
-supernaturelle, choisissez parmi les actions <strong>celle que vous espérez ne pas subir</strong>
-et additionnez un jet à votre <code>Cran</code>.</p>
-<p>Avec 10 ou plus, vous êtes totalement épargné. Entre 7 et 9, le MdJ choisit une action hormis celle
-que vous avez sélectionné. <em>Sur un échec, c'est celle que vous ne vouliez pas
-qui arrive&nbsp;!</em></p>
+<p><strong><em>Quand vous essayez de résister</em></strong>, à une blessure, une contrainte ou 
+une horreur surnaturelle, choisissez parmi les actions <strong>celle que vous
+espérez ne pas subir</strong> et additionnez un jet à votre <code>Cran</code>.</p>
+<p>Avec 10 ou plus, vous êtes totalement épargné. Entre 7 et 9, le MdJ choisit
+une action hormis celle que vous avez sélectionné. <em>Sur un échec, c'est celle
+que vous ne vouliez pas
+qui arrive !</em></p>
 <ul>
 <li>Scotché, laissé là sans défense.</li>
 <li>Panique, fuite, retraite.</li>
@@ -159,17 +161,19 @@ qui arrive&nbsp;!</em></p>
 <h2 id="periode-creuse">PÉriode creuse</h2>
 <p>Quand vous êtes en période creuse, sans boulot, choisissez une option :</p>
 <ul>
-<li><strong>Aller au pub</strong>&nbsp;: soigne le trauma (s'il est supérieur à 6, descendez à 6,
+<li><strong>Aller au pub</strong> : soigne le trauma (s'il est supérieur à 6, descendez à 6,
 s'il est inférieur ou égal à 6, passez à zéro).</li>
-<li><strong>Visiter le guérisseur</strong>&nbsp;: soigne les dommages (s'ils sont supérieurs à 9,
-  descendez à 9&nbsp;; égaux à 9, descendez à 6&nbsp;; inférieurd ou égaux à 6, tout est guéri).</li>
-<li><strong>Faire un petit boulot</strong> - au choix&nbsp;: videur, courrier, artisan, brigand, docker,
-chasse-leviathan, employé dans un crématorium, une distillerie, une forge, un abattoir, une étable,
-un commerce. Récupérez 2-<code>Pécules</code> ou 1-<code>Faveur</code>.</li>
+<li><strong>Visiter le guérisseur</strong> : soigne les dommages (s'ils sont supérieurs à 9,
+descendez à 9 ; égaux à 9, descendez à 6 ; inférieurs ou égaux à 6, tout
+est guéri).</li>
+<li><strong>Faire un petit boulot</strong> - au choix : videur, courrier, artisan, brigand,
+docker, chasse-leviathan, employé dans un crématorium, une distillerie,
+une forge, un abattoir, une étable, un commerce. Récupérez 2-<code>Pécules</code> ou
+1-<code>Faveur</code>.</li>
 </ul>
 <p>Vous pouvez choisir de dépenser un <code>Jeton</code> par option supplémentaire.
- Vous pouvez choisir deux fois la même option.</p>
-<p><strong><code>Note</code>&nbsp;: quand on vous demande de faire un jet, prenez deux dés à 6 faces et 
+Vous pouvez choisir deux fois la même option.</p>
+<p><strong><code>Note</code> : quand on vous demande de faire un jet, prenez deux dés à 6 faces et 
 additionnez-les.</strong></p>
 	</div>
 </div>

--- a/src/page-1-col-1.md
+++ b/src/page-1-col-1.md
@@ -1,34 +1,34 @@
 ## force
 
-**_Quand vous employez la force_**, jet+`Force` et choisissez parmi les options.
+**_Quand vous employez la force_**, additionnez un jet à votre `Force` et
+choisissez parmi les options.
 
-Sur 12+, trois. Sur 10-11, deux. Sur 7-9, une.
+Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.
 
-* Vous infligez un grand Dommage.
-* Vous recevez un léger Dommage en retour.
-* Vous les repoussez, capturez quelque chose, ou créez une opportunité.
+* Vous infligez un dommage important.
+* Vous subissez peu de dommage en retour.
+* Vous les repoussez, capturez quelque chose, ou profitez de la situation.
 
 ## finesse
 
-***Quand vous usez de finesse***, jet+`Finesse` et choisissez parmi les options.
+***Quand vous usez de finesse***, additionnez un jet à votre `Finesse` et
+choisissez parmi les options.
 
-Sur 12+, trois. Sur 10-11, deux. Sur 7-9, une.
+Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.
 
 * Vous le faites rapidement.
-* Vous évitez les ennuis, d'être compromis, le prix à payer.
-* Vous le faites de manière impressionnante, avec classe.
+* Vous échappez aux ennuis, à la compromission, au prix à payer.
+* Vous réussissez remarquablement, avec classe, ou avec un meilleur résultat.
 
 ## LuciditÉ
 
-***Quand vous essayez d'être perspicace***, jet+`Lucidité`.
+***Quand vous essayez d'être perspicace***, additionnez un jet à votre `Lucidité`.
 
-Sur 12+, gardez-en trois. Sur 10-11, gardez-en deux. Sur 7-9, gardez-en une.
-
-Conservez vos options en réserve en les troquant "une pour une" contre une
-question à poser au MdJ à tout moment de la scène.
+Avec 12 ou plus, gardez-en trois ; 10-11, deux ; 7-9, une.Échangez vos options
+contre autant de questions à poser au MdJ à tout moment de la scène.
 
 * Que se passe-t-il vraiment ici ?
-* Qu'est-ce que je dois regarder / chercher ?
+* À quoi devrais-je être attentif ?
 * Quel est le meilleur moyen pour _____________ ?
 * Que ressentent-ils vraiment ?
 * Que veulent-ils ?
@@ -39,8 +39,8 @@ question immédiatement.*
 
 ## Aider / InterfÉrer
 
-Pour chaque mouvement ci-dessus (`Force`, `Finesse`, `Lucidité`), vous pouvez
+Pour chacune des actions précédentes (`Force`, `Finesse`, `Lucidité`), vous pouvez
 également dépenser une de vos options en tant qu'aide ou gêne :
 
-* Vous aidez quelqu'un, ils reçoivent un bonus de +1 à leur jet.
-* Vous gênez quelqu'un, ils reçoivent un malus de -2.
+* Ceux que vous aidez reçoivent un bonus de +1 à leur jet.
+* Ceux que vous gênez reçoivent un malus de -2.

--- a/src/page-1-col-1.md
+++ b/src/page-1-col-1.md
@@ -10,7 +10,7 @@ Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.
 
 ## finesse
 
-***Quand vous usez de finesse***, jet+`Finesse` et choisissez parmi les options. 
+***Quand vous usez de finesse***, jet+`Finesse` et choisissez parmi les options.
 
 Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.
 

--- a/src/page-1-col-1.md
+++ b/src/page-1-col-1.md
@@ -1,7 +1,6 @@
 ## force
 
-**_Quand vous employez la force_**, additionnez un jet à votre `Force` et
-choisissez parmi les options.
+**_Quand vous employez la force_**, jet+`Force` et choisissez parmi les options.
 
 Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.
 
@@ -11,8 +10,7 @@ Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.
 
 ## finesse
 
-***Quand vous usez de finesse***, additionnez un jet à votre `Finesse` et
-choisissez parmi les options.
+***Quand vous usez de finesse***, jet+`Finesse` et choisissez parmi les options. 
 
 Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.
 
@@ -22,9 +20,9 @@ Avec 12 ou plus, trois options ; 10-11, deux ; 7-9, une.
 
 ## LuciditÉ
 
-***Quand vous essayez d'être perspicace***, additionnez un jet à votre `Lucidité`.
+***Quand vous essayez d'être perspicace***, jet+`Lucidité`.
 
-Avec 12 ou plus, gardez-en trois ; 10-11, deux ; 7-9, une.Échangez vos options
+Avec 12 ou plus, gardez-en trois ; 10-11, deux ; 7-9, une. Échangez vos options
 contre autant de questions à poser au MdJ à tout moment de la scène.
 
 * Que se passe-t-il vraiment ici ?
@@ -39,8 +37,8 @@ question immédiatement.*
 
 ## Aider / InterfÉrer
 
-Pour chacune des actions précédentes (`Force`, `Finesse`, `Lucidité`), vous pouvez
-également dépenser une de vos options en tant qu'aide ou gêne :
+Pour chacun des mouvements précédents (`Force`, `Finesse`, `Lucidité`), vous
+pouvez également dépenser une de vos options en tant qu'aide ou gêne :
 
 * Ceux que vous aidez reçoivent un bonus de +1 à leur jet.
 * Ceux que vous gênez reçoivent un malus de -2.

--- a/src/page-1-col-3.md
+++ b/src/page-1-col-3.md
@@ -1,33 +1,36 @@
 ## Cran
 
-***Quand vous résistez***, à une blessure, une contrainte ou une horreur
-supernaturelle, choisissez parmi les options **celle que vous ne voulez pas**
-et faites un jet+`Cran`.
+***Quand vous essayez de résister***, à une blessure, une contrainte ou 
+une horreur supernaturelle, choisissez parmi les actions **celle que vous
+espérez ne pas subir** et additionnez un jet à votre `Cran`.
 
-Sur un 10+, aucune n'arrive. Sur un 7-9, le MdJ choisit une option hormis celle
-que vous avez sélectionné. *Sur un échec, c'est celle que vous ne vouliez pas
+Avec 10 ou plus, vous êtes totalement épargné. Entre 7 et 9, le MdJ choisit
+une action hormis celle que vous avez sélectionné. *Sur un échec, c'est celle
+que vous ne vouliez pas
 qui arrive !*
 
 * Scotché, laissé là sans défense.
 * Panique, fuite, retraite.
-* Effondrement, laissez-aller, abandon.
+* Effondrement, laisser-aller, abandon.
 * Rage, perte de contrôle, provoque des dommages involontaires.
-* Souffre un Trauma ou un Dommage supplémentaire.
+* Souffre d'un trauma ou d'un dommage supplémentaire.
 
 ## PÉriode creuse
 
 Quand vous êtes en période creuse, sans boulot, choisissez une option :
 
-* **Aller au pub** : Soigne le Trauma (si plus élevé que 6, descendez à 6, si
-  6 ou inférieur, passez à zéro).
-* **Visitez le guérisseur** : Soigne les Dommages (si plus élevé que 9,
-  descendez à 9. Si à 9, descendez à 6. Si 6 ou inférieur, tout est guéri).
-* **Faites un petit job** - au choix : videur, courrier, artisan, crematorium,
-  crime, distillerie, docks, forge, chasse-leviathan, abattoir, étable,
-  commerce. Récupérez 2-`Pécules` ou 1-`Faveur`.
+* **Aller au pub** : soigne le trauma (s'il est supérieur à 6, descendez à 6,
+s'il est inférieur ou égal à 6, passez à zéro).
+* **Visiter le guérisseur** : soigne les dommages (s'ils sont supérieurs à 9,
+descendez à 9 ; égaux à 9, descendez à 6 ; inférieurd ou égaux à 6, tout
+est guéri).
+* **Faire un petit boulot** - au choix : videur, courrier, artisan, brigand,
+docker, chasse-leviathan, employé dans un crématorium, une distillerie,
+une forge, un abattoir, une étable, un commerce. Récupérez 2-`Pécules` ou
+1-`Faveur`.
 
-Vous pouvez choisir de dépenser des `Jetons` (un pour un) pour chacune des
-options. Vous pouvez choisir deux fois la même option.
+Vous pouvez choisir de dépenser un `Jeton` par option supplémentaire.
+Vous pouvez choisir deux fois la même option.
 
-**`Note`: Quand on vous demande de faire un jet, prendez deux dés à 6 faces et 
+**`Note` : quand on vous demande de faire un jet, prenez deux dés à 6 faces et 
 additionnez-les.**

--- a/src/page-1-col-3.md
+++ b/src/page-1-col-3.md
@@ -1,7 +1,7 @@
 ## Cran
 
 ***Quand vous essayez de résister***, à une blessure, une contrainte ou 
-une horreur supernaturelle, choisissez parmi les actions **celle que vous
+une horreur surnaturelle, choisissez parmi les actions **celle que vous
 espérez ne pas subir** et additionnez un jet à votre `Cran`.
 
 Avec 10 ou plus, vous êtes totalement épargné. Entre 7 et 9, le MdJ choisit
@@ -22,7 +22,7 @@ Quand vous êtes en période creuse, sans boulot, choisissez une option :
 * **Aller au pub** : soigne le trauma (s'il est supérieur à 6, descendez à 6,
 s'il est inférieur ou égal à 6, passez à zéro).
 * **Visiter le guérisseur** : soigne les dommages (s'ils sont supérieurs à 9,
-descendez à 9 ; égaux à 9, descendez à 6 ; inférieurd ou égaux à 6, tout
+descendez à 9 ; égaux à 9, descendez à 6 ; inférieurs ou égaux à 6, tout
 est guéri).
 * **Faire un petit boulot** - au choix : videur, courrier, artisan, brigand,
 docker, chasse-leviathan, employé dans un crématorium, une distillerie,


### PR DESCRIPTION
Avant d'aller plus loin, et pour être certain que nous sommes bien en phase, voici un premier différentiel prenant en compte la première page uniquement (sans la feuille de personnage).
Quelques remarques sur ces modifications : 
1. Quelques parties très concises dans l'original on été réécrites en un peu plus long pour améliorer la lisibilité du document (c'est le cas pour les jets, en particulier).
2. D'autres corrections sont d'un ordre purement typographique : ajout d'espace avant un deux-points, suppression de majuscules abusives. Je n'ai pas trouvé dans Markdown (mais pas trop cherché non plus...) comment faire des espaces insécables. Pour essai, ils ont été ajouté à la main dans le fichier HTML (je n'ai volontairement pas envoyé le fichier généré avec build.py). Cela dit, il semblerait que tout tombe à peu près bien, et leur absence ne devrait pas être visible. 
3. Quelques libertés ont été prises avec le texte original pour que ça colle plus à l'idée.

Pour en revenir aux majuscules, j'ai en particulier supprimé celles des mots-clef comme Trauma, Dommage, mais pas à ceux inclus dans une balise code, comme cela est fait dans l'original. Si on veut faire ressortir ces mots, peut-être serait-il préférable d'utiliser balise (code ou autre) ?

Ah, je viens de m’apercevoir qu'il manque un espace colonne 1, ligne 27 (avant Échangez vos options).

Voilà pour l'instant.
